### PR TITLE
Call updater functions when component is remounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,26 @@
 # enzyme-context (vNext)
 
+- Fix an issue where components would not listen to context changes after going through an unmount()/mount() cycle
+
 ### enzyme-context-apollo (vNext)
+
+- Fix an issue where components would not listen to context changes after going through an unmount()/mount() cycle
 
 ### enzyme-context-react-router-3 (vNext)
 
+- Fix an issue where components would not listen to context changes after going through an unmount()/mount() cycle
+
 ### enzyme-context-react-router-4 (vNext)
+
+- Fix an issue where components would not listen to context changes after going through an unmount()/mount() cycle
 
 ### enzyme-context-redux (vNext)
 
+- Fix an issue where components would not listen to context changes after going through an unmount()/mount() cycle
+
 ### enzyme-context-utils (vNext)
+
+- Fix an issue where components would not listen to context changes after going through an unmount()/mount() cycle
 
 # enzyme-context (v1.0.3)
 

--- a/packages/enzyme-context-react-router-4/src/enzyme-context-react-router-4.spec.tsx
+++ b/packages/enzyme-context-react-router-4/src/enzyme-context-react-router-4.spec.tsx
@@ -38,6 +38,16 @@ describe('enzyme-context-react-router-4', () => {
     expect(page().text()).toBe('id is: 1612');
   });
 
+  it('responds to history after the component is remounted', () => {
+    component.unmount();
+    component.mount();
+    expect(page().exists()).toBe(false);
+
+    history.push('/my/url/1612');
+    component.update();
+    expect(page().exists()).toBe(true);
+  });
+
   it('allows configuration to be passed', () => {
     const mount = createMount({
       history: routerContext(),

--- a/packages/enzyme-context-utils/src/ValueWatcher.ts
+++ b/packages/enzyme-context-utils/src/ValueWatcher.ts
@@ -1,4 +1,4 @@
-type Listener<V> = (value: V) => void;
+export type Listener<V> = (value: V) => void;
 
 /**
  * A class that keeps track of a single value and notifies listeners when that value changes.

--- a/packages/enzyme-context-utils/src/enzyme-context-utils.spec.tsx
+++ b/packages/enzyme-context-utils/src/enzyme-context-utils.spec.tsx
@@ -106,6 +106,21 @@ describe('enzyme-context-utils', () => {
       debug.emit('debug', true);
     });
 
+    it('supports listening again after stopping', () => {
+      watcher.stop();
+      const listener = jest.fn();
+      watcher.listen(listener);
+
+      debug.emit('debug', true);
+      expect(listener).toHaveBeenCalledWith({
+        myStuff: {
+          foo: 'hello',
+          bar: 'world',
+        },
+        debug: true,
+      });
+    });
+
     it('supports passing childContextTypes directly', () => {
       const Wrapper: React.SFC = ({ children }) => {
         return (

--- a/packages/enzyme-context/src/enzyme-context.spec.tsx
+++ b/packages/enzyme-context/src/enzyme-context.spec.tsx
@@ -152,6 +152,37 @@ describe('enzyme-context', () => {
         expect(component.exists()).toBe(false);
         expect(pluginA.unmounter).toHaveBeenCalled();
       });
+
+      it('does nothing if mount() is called when the component is already mounted', () => {
+        pluginA.updater.mockClear();
+        component.mount();
+        expect(pluginA.updater).not.toHaveBeenCalled();
+      });
+
+      it('calls the plugin updaters again if the component is unmounted and then mounted', () => {
+        pluginA.updater.mockClear();
+        const unmounter = jest.fn();
+        pluginA.updater.mockReturnValue(unmounter);
+
+        component.unmount();
+        pluginA.unmounter.mockClear();
+        expect(pluginA.updater).not.toHaveBeenCalled();
+        component.mount();
+        expect(pluginA.updater).toHaveBeenCalledWith(component);
+
+        expect(unmounter).not.toHaveBeenCalled();
+        component.unmount();
+        try {
+          component.unmount();
+        } catch (e) {}
+        expect(pluginA.unmounter).not.toHaveBeenCalled();
+        expect(unmounter).toHaveBeenCalledTimes(1);
+
+        pluginA.updater.mockClear();
+        component.mount();
+        component.mount();
+        expect(pluginA.updater).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/packages/enzyme-context/src/index.ts
+++ b/packages/enzyme-context/src/index.ts
@@ -8,7 +8,7 @@ import {
   ShallowRendererProps,
 } from 'enzyme';
 import { EnzymePlugins, GetTestObjects, GetOptions } from './Types';
-import { executePlugins, patchUnmount } from './Utils';
+import { executePlugins, hookIntoLifecycle } from './Utils';
 
 /**
  * Creates a specialized enzyme mount() function with context set up.
@@ -31,7 +31,7 @@ export function createMount<P extends EnzymePlugins>(plugins: P) {
     const pluginResults = executePlugins(plugins, node, options || {});
     const component = baseMount(pluginResults.node, pluginResults.options);
 
-    patchUnmount(pluginResults, component);
+    hookIntoLifecycle(pluginResults, component);
 
     return {
       ...(pluginResults.controllers as object),
@@ -69,7 +69,7 @@ export function createShallow<P extends EnzymePlugins>(plugins: P) {
     const pluginResults = executePlugins(plugins, node, options || {});
     const component = baseShallow(pluginResults.node, pluginResults.options);
 
-    patchUnmount(pluginResults, component);
+    hookIntoLifecycle(pluginResults, component);
 
     return {
       ...(pluginResults.controllers as object),


### PR DESCRIPTION
Fix an issue where components would not listen to context changes after going through an unmount()/mount() cycle