### PR TITLE
Use React Router's createMemoryHistory in reeact-router-3-package

### DIFF
--- a/packages/enzyme-context-react-router-3/src/enzyme-context-react-router-3.spec.tsx
+++ b/packages/enzyme-context-react-router-3/src/enzyme-context-react-router-3.spec.tsx
@@ -61,4 +61,14 @@ describe('enzyme-context-react-router-3', () => {
     }));
     expect(component.find(Component).exists()).toBe(true);
   });
+
+  it('supports accessing locations query', () => {
+    ({ component } = mount(
+      <Route path="/foo/bar" component={props => <div>{props.location.query.test}</div>} />,
+      {
+        routerConfig: { entries: ['/foo/bar?test=1'] },
+      },
+    ));
+    expect(component.text()).toBe('1');
+  });
 });

--- a/packages/enzyme-context-react-router-3/src/index.tsx
+++ b/packages/enzyme-context-react-router-3/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { EnzymePlugin, ContextWatcher, bindContextToWrapper } from 'enzyme-context-utils';
-import { History, createMemoryHistory, HistoryOptions, MemoryHistoryOptions } from 'history';
-import { RouterContext, Router, Route } from 'react-router';
+import { History, HistoryOptions, MemoryHistoryOptions } from 'history';
+import { RouterContext, Router, Route, createMemoryHistory } from 'react-router';
 import { wrapRoute } from './Utils';
 
 export interface RouterPluginMountOptions {


### PR DESCRIPTION
### All Submissions:

React Router v3 uses its own custom wrapper of `createMemoryHistory` (which comes from https://github.com/ReactTraining/history).  Without using this wrapper you are unable to access `location.query`, which is a nicely parsed version of `location.search`.  As such we should use React Router v3's version of `createMemoryHistory` in this plugin to take advantage of this functionality.

* [ X ] Have you followed the guidelines in our Contributing document?
* [ X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ X ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ X ] Have you written new tests for your core changes, as applicable?
* [ X ] Have you successfully ran tests with your changes locally?
