### PR TITLE
Make enzyme-context return enzyme wrappers instead of objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,22 @@
 # enzyme-context (vNext)
 
+- Change enzyme-context's `mount()` and `shallow()` functions to return a `ReactWrapper` and `ShallowWrapper` instead of an object. Plugin controllers are then attached directly to the returned Enzyme wrapper. To maintain backwards-compatibility with previous versions of enzyme-context a `component` attribute is also attached to the wrapper that just references itself.
+
 ### enzyme-context-apollo (vNext)
+
+- Update docs to reflect new enzyme-context API
 
 ### enzyme-context-react-router-3 (vNext)
 
+- Update docs to reflect new enzyme-context API
+
 ### enzyme-context-react-router-4 (vNext)
 
+- Update docs to reflect new enzyme-context API
+
 ### enzyme-context-redux (vNext)
+
+- Update docs to reflect new enzyme-context API
 
 ### enzyme-context-utils (vNext)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API
 
-## `createMount(plugins) => (node: React.ReactElement, options? Object) => Object`
+## `createMount(plugins) => (node: React.ReactElement, options? Object) => ContextReactWrapper`
 
 #### Arguments
 
@@ -8,15 +8,14 @@
 
 #### Returns
 
-A mount function: `(node: React.ReactElement, options?: Object) => Object`: A function that takes the same arguments as [mount](https://airbnb.io/enzyme/docs/api/mount.html#mountnode-options--reactwrapper) but can also accept additional `options` (as specified by the provided `plugins`.)
+A mount function: `(node: React.ReactElement, options?: Object) => ContextReactWrapper`: A function that takes the same arguments as [mount](https://airbnb.io/enzyme/docs/api/mount.html#mountnode-options--reactwrapper) but can also accept additional `options` (as specified by the provided `plugins`.)
 
 - **Arguments**
   1. `node` (`React.ReactElement`): The node to render
   2. `options` (`Object` [optional]): The same options that can be passed to [enzyme's mount](https://airbnb.io/enzyme/docs/api/mount.html#mountnode-options--reactwrapper) _plus_ any options the plugins you've added handle.
 - **Returns**
-  - An object with the following attributes:
-    - `component` (`ReactWrapper`): an enzyme `ReactWrapper` (what a plain enzyme `mount()`) returns.
-    - `[keyof plugins]: EnzymePlugin['controller']`: the returned object will have a key that matches each key in the `plugins` you provide. The value will be whatever [`controller`](https://github.com/trialspark/enzyme-context/blob/007022a7bddb7e843a27563f7918276af2ebb707/packages/enzyme-context-utils/src/Types.ts#L9) the plugin provides. For example, the `enzyme-context-redux` plugin provides a `Store`; the `enzyme-context-react-router-4` plugin provides a `History`.
+  - A `ReactWrapper` with the following attributes:
+    - `[keyof plugins]: EnzymePlugin['controller']`: the returned `ReactWrapper` will have a key that matches each key in the `plugins` you provide. The value will be whatever [`controller`](https://github.com/trialspark/enzyme-context/blob/007022a7bddb7e843a27563f7918276af2ebb707/packages/enzyme-context-utils/src/Types.ts#L9) the plugin provides. For example, the `enzyme-context-redux` plugin provides a `Store`; the `enzyme-context-react-router-4` plugin provides a `History`.
 
 #### Example
 
@@ -44,29 +43,27 @@ import { mount } from '../test-utils/enzyme'; // import from the module defined 
 import MyComponent from './MyComponent';
 
 describe('MyComponent', () => {
-  let component;
-  let store;
-  let history;
+  let wrapper;
 
   beforeEach(() => {
-    ({ component, store, history } = mount(<MyComponent />));
+    wrapper = mount(<MyComponent />);
   });
 
   it('responds to redux state changes', () => {
-    store.dispatch({ type: 'SOME_ACTION' });
-    component.update();
-    expect(component.text()).toBe('...');
+    wrapper.store.dispatch({ type: 'SOME_ACTION' });
+    wrapper.update();
+    expect(wrapper.text()).toBe('...');
   });
 
   it('responds to location changes', () => {
-    history.push('/my/new/url');
-    component.update();
-    expect(component.text()).toBe('...');
+    wrapper.history.push('/my/new/url');
+    wrapper.update();
+    expect(wrapper.text()).toBe('...');
   });
 });
 ```
 
-## `createShallow(plugins) => (node: React.ReactElement, options? Object) => Object`
+## `createShallow(plugins) => (node: React.ReactElement, options? Object) => ContextShallowWrapper`
 
 #### Arguments
 
@@ -74,14 +71,13 @@ describe('MyComponent', () => {
 
 #### Returns
 
-A shallow function: `(node: React.ReactElement, options?: Object) => Object`: A function that takes the same arguments as [shallow](https://airbnb.io/enzyme/docs/api/shallow.html#shallownode-options--shallowwrapper) but can also accept additional `options` (as specified by the provided `plugins`.)
+A shallow function: `(node: React.ReactElement, options?: Object) => ContextShallowWrapper`: A function that takes the same arguments as [shallow](https://airbnb.io/enzyme/docs/api/shallow.html#shallownode-options--shallowwrapper) but can also accept additional `options` (as specified by the provided `plugins`.)
 
 - **Arguments**
   1. `node` (`React.ReactElement`): The node to render
   2. `options` (`Object` [optional]): The same options that can be passed to [enzyme's shallow](https://airbnb.io/enzyme/docs/api/shallow.html#shallownode-options--shallowwrapper) _plus_ any options the plugins you've added handle.
 - **Returns**
-  - An object with the following attributes:
-    - `component` (`ShallowWrapper`): an enzyme `ShallowWrapper` (what a plain enzyme `shallow()`) returns.
+  - An `ShallowWrapper` with the following attributes:
     - `[keyof plugins]: EnzymePlugin['controller']`: the returned object will have a key that matches each key in the `plugins` you provide. The value will be whatever [`controller`](https://github.com/trialspark/enzyme-context/blob/007022a7bddb7e843a27563f7918276af2ebb707/packages/enzyme-context-utils/src/Types.ts#L9) the plugin provides. For example, the `enzyme-context-redux` plugin provides a `Store`; the `enzyme-context-react-router-4` plugin provides a `History`.
 
 #### Example
@@ -106,28 +102,26 @@ export const shallow = createShallow({
 **MyComponent.spec.tsx**
 
 ```javascript
-import { mount } from '../test-utils/enzyme'; // import from the module defined above
+import { shallow } from '../test-utils/enzyme'; // import from the module defined above
 import MyComponent from './MyComponent';
 
 describe('MyComponent', () => {
-  let component;
-  let store;
-  let history;
+  let wrapper;
 
   beforeEach(() => {
-    ({ component, store, history } = mount(<MyComponent />));
+    wrapper = shallow(<MyComponent />);
   });
 
   it('responds to redux state changes', () => {
-    store.dispatch({ type: 'SOME_ACTION' });
-    component.update();
-    expect(component.text()).toBe('...');
+    wrapper.store.dispatch({ type: 'SOME_ACTION' });
+    wrapper.update();
+    expect(wrapper.text()).toBe('...');
   });
 
   it('responds to location changes', () => {
-    history.push('/my/new/url');
-    component.update();
-    expect(component.text()).toBe('...');
+    wrapper.history.push('/my/new/url');
+    wrapper.update();
+    expect(wrapper.text()).toBe('...');
   });
 });
 ```

--- a/docs/authoring-plugins.md
+++ b/docs/authoring-plugins.md
@@ -16,7 +16,7 @@ Creating a plugin for `enzyme-context` is relatively straightforward because an 
 - An Object with the following attributes
 
   - `node` (`React.ReactElement`): the react element to mount
-  - `controller` (`any`): the object this component wants `mount`/`shallow` to return along with the enzyme wrapper. For example:
+  - `controller` (`any`): the object this plugin wants to attach to the Enzyme wrapper. For example:
 
     ```javascript
     class Person {
@@ -38,9 +38,9 @@ Creating a plugin for `enzyme-context` is relatively straightforward because an 
     const mount = createMount({
       p: myPlugin,
     });
-    const { component, p } = mount(<MyComponent />);
+    const wrapper = mount(<MyComponent />);
 
-    p.sayHello();
+    wrapper.p.sayHello();
     ```
 
   - `options` (`Object`): options to feed into `mount()`/`enzyme()`. This is how plugins provide context. For example:
@@ -68,9 +68,9 @@ Creating a plugin for `enzyme-context` is relatively straightforward because an 
     }
     MyComponent.childContextTypes = { person: PropTypes.instanceOf(Person) };
 
-    const { component } = mount(<MyComponent />);
+    const wrapper = mount(<MyComponent />);
 
-    component.find('button').simulate('click');
+    wrapper.find('button').simulate('click');
     ```
 
   - `updater` (`(wrapper: ReactWrapper | ShallowWrapper) => () => void` [optional]): This function will be called immediately after the enzyme wrapper is created. It can be used to setup listeners that update the wrapper after it has been created. For example, if our plugin was supplying context that contained a list of all the `window.postMessage` events we've received, we could do something like this:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,12 +34,11 @@ import { mount } from 'test-utils/enzyme';
 import MyComponent from './MyComponent';
 
 describe('<MyComponent />', () => {
-  let component;
+  let wrapper;
 
   beforeEach(() => {
-    // mount returns an object with:
-    //   - component: the mounted enzyme wrapper
-    ({ component } = mount(<MyComponent />));
+    // shallow()/mount() your component like usual!
+    wrapper = mount(<MyComponent />);
   });
 });
 ```

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -13,11 +13,11 @@ function MyComponent(props) {
   );
 }
 
-const component = mount(<MyComponent company="TrialSpark" years={2} />);
-expect(component.text()).toBe('I have worked at TrialSpark for 2 years.');
+const wrapper = mount(<MyComponent company="TrialSpark" years={2} />);
+expect(wrapper.text()).toBe('I have worked at TrialSpark for 2 years.');
 
-component.setProps({ company: 'Facebook', years: 0 });
-expect(component.text()).toBe('I have worked at Facebook for 0 years.');
+wrapper.setProps({ company: 'Facebook', years: 0 });
+expect(wrapper.text()).toBe('I have worked at Facebook for 0 years.');
 ```
 
 **Wrong!** And there's a _single_ react feature we can blame for this: context. Context allows components to provide data that _all_ its ancestors access _without_ passing that data down as props. In practice, this is a helpful feature, and it powers some of the most popular libraries out there today: `react-redux`, `react-router`, `react-apollo`, to just name a few.
@@ -34,7 +34,7 @@ const mapStateToProps = state => ({
 MyComponent = connect(mapStateToProps)(MyComponent);
 
 // Error: store missing in context
-const component = mount(<MyComponent />);
+const wrapper = mount(<MyComponent />);
 ```
 
 One common way to solve this problem is to render your component inside of a provider:
@@ -43,7 +43,7 @@ One common way to solve this problem is to render your component inside of a pro
 import { Provider } from 'react-redux';
 import store from './myStore';
 
-const component = mount(
+const wrapper = mount(
   <Provider store={store}>
     <MyComponent />
   </Provider>,
@@ -53,9 +53,9 @@ const component = mount(
 However, this doesn't play very nicely with enzyme:
 
 ```javascript
-component.type(); // Provider, not MyComponent
-component.setProps({}); // Setting props on the Provider, not MyComponent
-component.instance(); // Instance of Provider, not MyComponent
+wrapper.type(); // Provider, not MyComponent
+wrapper.setProps({}); // Setting props on the Provider, not MyComponent
+wrapper.instance(); // Instance of Provider, not MyComponent
 ```
 
 Thankfully, `enzyme` allows us to pass context to our components when we mount this:
@@ -65,7 +65,7 @@ import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import store from './myStore';
 
-const component = mount(<MyComponent />, {
+const wrapper = mount(<MyComponent />, {
   context: {
     store,
   },
@@ -74,7 +74,7 @@ const component = mount(<MyComponent />, {
   },
 });
 
-component.type(); // MyComponent
+wrapper.type(); // MyComponent
 ```
 
 ## The problems with passing context to enzyme

--- a/packages/enzyme-context-apollo/README.md
+++ b/packages/enzyme-context-apollo/README.md
@@ -55,22 +55,21 @@ import { mount } from './test-utils/enzyme'; // import the mount created with en
 import MyComponent from './MyComponent';
 
 describe('<MyComponent />', () => {
-  let component;
-  let client;
+  let wrapper;
 
   beforeEach(async () => {
-    ({ component, store } = mount(<MyComponent />));
+    wrapper = mount(<MyComponent />);
     // Reseting the apollo store does two things:
     //  1. Abort any in-flight requests that may have been leftover from the last spec
     //  2. Return a Promise that allows us to deterministically wait until all of our
     //     component's queries have loaded before proceeding with our tests.
-    await client.resetStore();
+    await wrapper.client.resetStore();
     // Update the Enzyme wrapper after the queries have loaded
-    component.update();
+    wrapper.update();
   });
 
   it('renders data from an apollo query', () => {
-    expect(component.text()).toContain('Viewer: Joe Dart');
+    expect(wrapper.text()).toContain('Viewer: Joe Dart');
   });
 });
 ```
@@ -150,7 +149,7 @@ This plugin also allows some configuration to be passed at mount-time:
 1. `apolloMocks` (`IMocks` [optional]): resolvers for the mock graphql backend. These objects are the same as the ones outlined in the [Customizing mocks section of `graphql-tools`'s docs](https://www.apollographql.com/docs/graphql-tools/mocking.html#Customizing-mocks). The mocks defined here will be deeply merged with the ones defined at plugin configuration time.
    - Example:
      ```javascript
-     ({ component, client } = mount(<MyComponent />, {
+     const wrapper = mount(<MyComponent />, {
        apolloMocks: {
          Query: () => ({
            viewer: () => ({
@@ -160,5 +159,5 @@ This plugin also allows some configuration to be passed at mount-time:
            }),
          }),
        },
-     }));
+     });
      ```

--- a/packages/enzyme-context-react-router-3/README.md
+++ b/packages/enzyme-context-react-router-3/README.md
@@ -38,30 +38,29 @@ import { Route, withRouter } from 'react-router';
 import MyComponent from './MyComponent';
 
 describe('<MyComponent />', () => {
-  let component;
-  let history;
+  let wrapper;
 
   beforeEach(() => {
-    ({ component, history } = mount(<Route path="/my/path" component={MyComponent} />));
+    wrapper = mount(<Route path="/my/path" component={MyComponent} />);
   });
 
   it('renders when active', () => {
-    expect(component.find(MyComponent).exists()).toBe(false);
-    history.push('/my/path');
-    component.update();
-    expect(component.find(MyComponent).exists()).toBe(true);
+    expect(wrapper.find(MyComponent).exists()).toBe(false);
+    wrapper.history.push('/my/path');
+    wrapper.update();
+    expect(wrapper.find(MyComponent).exists()).toBe(true);
   });
 
   it('renders non-route components', () => {
     let Component = props => <div>Path is: {props.location.pathname}</div>;
     Component = withRouter(Component);
 
-    ({ component } = mount(<Component />, {
+    wrapper = mount(<Component />, {
       routerConfig: {
         entries: ['/foo/bar'],
       },
-    }));
-    expect(component.text()).toBe('Path is: /foo/bar');
+    });
+    expect(wrapper.text()).toBe('Path is: /foo/bar');
   });
 });
 ```
@@ -95,9 +94,9 @@ This plugin also allows some configuration to be passed at mount-time:
 1. `routerConfig` (`Object` [optional]): any of the configuration options of `history`'s `createMemoryHistory()`. For example, we can set the URL _before_ our component mounts like so:
 
    ```javascript
-   ({ component, history } = mount(<MyComponent />, {
+   const wrapper = mount(<MyComponent />, {
      routerConfig: {
        entries: ['/my/url'],
      },
-   }));
+   });
    ```

--- a/packages/enzyme-context-react-router-4/README.md
+++ b/packages/enzyme-context-react-router-4/README.md
@@ -38,18 +38,17 @@ import { Route } from 'react-router-dom';
 import MyComponent from './MyComponent';
 
 describe('<MyComponent />', () => {
-  let component;
-  let history;
+  let wrapper;
 
   beforeEach(() => {
-    ({ component, history } = mount(<Route path="/my/path" component={MyComponent} />));
+    wrapper = mount(<Route path="/my/path" component={MyComponent} />);
   });
 
   it('renders when active', () => {
-    expect(component.find(MyComponent).exists()).toBe(false);
-    history.push('/my/path');
-    component.update();
-    expect(component.find(MyComponent).exists()).toBe(true);
+    expect(wrapper.find(MyComponent).exists()).toBe(false);
+    wrapper.history.push('/my/path');
+    wrapper.update();
+    expect(wrapper.find(MyComponent).exists()).toBe(true);
   });
 });
 ```
@@ -82,9 +81,9 @@ This plugin also allows some configuration to be passed at mount-time:
 
 1. `routerConfig` (`Object` [optional]): any of the configuration [options of `history`'s `createMemoryHistory()`](https://github.com/ReactTraining/history#usage). For example, we can set the URL _before_ our component mounts like so:
    ```javascript
-   ({ component, history } = mount(<MyComponent />, {
+   const wrapper = mount(<MyComponent />, {
      routerConfig: {
        initialEntries: ['/my/url'],
      },
-   }));
+   });
    ```

--- a/packages/enzyme-context-react-router-4/src/enzyme-context-react-router-4.spec.tsx
+++ b/packages/enzyme-context-react-router-4/src/enzyme-context-react-router-4.spec.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { createMount } from 'enzyme-context';
+import { createMount, GetContextWrapper } from 'enzyme-context';
 import { ReactWrapper } from 'enzyme';
 import { RouteComponentProps } from 'react-router';
 import { Route } from 'react-router-dom';
-import { MemoryHistory } from 'history';
 import { routerContext } from '.';
 
 const MyComponent: React.SFC<RouteComponentProps<{ id: string }>> = props => {
@@ -11,8 +10,11 @@ const MyComponent: React.SFC<RouteComponentProps<{ id: string }>> = props => {
 };
 
 describe('enzyme-context-react-router-4', () => {
-  let component: ReactWrapper;
-  let history: MemoryHistory;
+  let component: GetContextWrapper<ReactWrapper, Plugins>;
+
+  type Plugins = {
+    history: ReturnType<typeof routerContext>;
+  };
 
   const page = () => component.find(MyComponent);
 
@@ -20,7 +22,7 @@ describe('enzyme-context-react-router-4', () => {
     const mount = createMount({
       history: routerContext(),
     });
-    ({ component, history } = mount(<Route path="/my/url/:id" component={MyComponent} />));
+    component = mount(<Route path="/my/url/:id" component={MyComponent} />);
   });
 
   afterEach(() => {
@@ -33,7 +35,7 @@ describe('enzyme-context-react-router-4', () => {
 
   it('returns history as a controller', () => {
     expect(page().exists()).toBe(false);
-    history.push('/my/url/1612');
+    component.history.push('/my/url/1612');
     component.update();
     expect(page().text()).toBe('id is: 1612');
   });
@@ -43,7 +45,7 @@ describe('enzyme-context-react-router-4', () => {
     component.mount();
     expect(page().exists()).toBe(false);
 
-    history.push('/my/url/1612');
+    component.history.push('/my/url/1612');
     component.update();
     expect(page().exists()).toBe(true);
   });
@@ -52,11 +54,11 @@ describe('enzyme-context-react-router-4', () => {
     const mount = createMount({
       history: routerContext(),
     });
-    ({ component } = mount(<Route path="/my/url/:id" component={MyComponent} />, {
+    component = mount(<Route path="/my/url/:id" component={MyComponent} />, {
       routerConfig: {
         initialEntries: ['/my/url/44'],
       },
-    }));
+    });
     expect(page().text()).toBe('id is: 44');
   });
 });

--- a/packages/enzyme-context-redux/README.md
+++ b/packages/enzyme-context-redux/README.md
@@ -39,17 +39,16 @@ import { mount } from './test-utils/enzyme'; // import the mount created with en
 import MyComponent from './MyComponent';
 
 describe('<MyComponent />', () => {
-  let component;
-  let store;
+  let wrapper;
 
   beforeEach(() => {
-    ({ component, store } = mount(<MyComponent />));
+    wrapper = mount(<MyComponent />);
   });
 
   it('responds to state updates', () => {
-    store.dispatch({ type: 'MY_ACTION' });
-    component.update();
-    expect(component.text()).toBe('...');
+    wrapper.store.dispatch({ type: 'MY_ACTION' });
+    wrapper.update();
+    expect(wrapper.text()).toBe('...');
   });
 });
 ```
@@ -91,7 +90,7 @@ This plugin also allows some configuration to be passed at mount-time:
 1. `initialActions` (`Action[]` [optional]): an array of initial actions to be dispatched _before_ the component is mounted. Useful to get the redux state into a desired form before the component initializes.
    - Example:
      ```javascript
-     ({ component, store } = mount(<MyComponent />, {
+     const wrapper = mount(<MyComponent />, {
        initialActions: [{ type: 'MY_ACTION' }],
-     }));
+     });
      ```

--- a/packages/enzyme-context-redux/src/enzyme-context-redux.spec.tsx
+++ b/packages/enzyme-context-redux/src/enzyme-context-redux.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { createMount } from 'enzyme-context';
+import { createMount, GetContextWrapper } from 'enzyme-context';
 import { ReactWrapper } from 'enzyme';
-import { createStore, Reducer, Store, ActionCreator, Action } from 'redux';
+import { createStore, Reducer, ActionCreator, Action } from 'redux';
 import { connect, MapStateToProps } from 'react-redux';
 import { reduxContext } from '.';
 
@@ -54,8 +54,11 @@ const reducer: Reducer<ReduxState, SetDebugAction> = (
 };
 
 describe('enzyme-context-redux', () => {
-  let component: ReactWrapper;
-  let store: Store<ReduxState>;
+  let component: GetContextWrapper<ReactWrapper, Plugins>;
+
+  type Plugins = {
+    store: ReturnType<typeof reduxContext>;
+  };
 
   beforeEach(() => {
     const mount = createMount({
@@ -63,7 +66,7 @@ describe('enzyme-context-redux', () => {
         createStore: () => createStore<ReduxState, any, {}, {}>(reducer),
       }),
     });
-    ({ component, store } = mount(<ConnectedComponent />));
+    component = mount(<ConnectedComponent />);
   });
 
   it('renders the component', () => {
@@ -72,7 +75,7 @@ describe('enzyme-context-redux', () => {
   });
 
   it('returns the store as a controller', () => {
-    store.dispatch(setDebug(true));
+    component.store.dispatch(setDebug(true));
     component.update();
     expect(component.text()).toBe('debug is: true');
   });
@@ -83,9 +86,9 @@ describe('enzyme-context-redux', () => {
         createStore: () => createStore<ReduxState, any, {}, {}>(reducer),
       }),
     });
-    ({ component } = mount(<ConnectedComponent />, {
+    component = mount(<ConnectedComponent />, {
       initialActions: [setDebug(true)],
-    }));
+    });
     expect(component.text()).toBe('debug is: true');
   });
 });

--- a/packages/enzyme-context/package.json
+++ b/packages/enzyme-context/package.json
@@ -35,6 +35,10 @@
   "dependencies": {
     "@types/lodash.merge": "^4.6.4",
     "enzyme-context-utils": "^1.0.2",
-    "lodash.merge": "^4.6.1"
+    "lodash.merge": "^4.6.1",
+    "once": "^1.4.0"
+  },
+  "devDependencies": {
+    "@types/once": "^1.4.0"
   }
 }

--- a/packages/enzyme-context/src/Types.ts
+++ b/packages/enzyme-context/src/Types.ts
@@ -12,9 +12,10 @@ export type GetControllers<P extends EnzymePlugins> = {
   [PluginName in keyof P]: ReturnType<P[PluginName]>['controller']
 };
 
-export type GetTestObjects<EW, P extends EnzymePlugins> = {
-  component: EW;
-} & GetControllers<P>;
+export type GetContextWrapper<EW, P extends EnzymePlugins> = EW &
+  GetControllers<P> & {
+    component: EW;
+  };
 
 export type GetOptions<RP, P extends EnzymePlugins> = RP &
   { [PluginName in keyof P]: SecondArgument<P[PluginName]> }[keyof P];

--- a/yarn.lock
+++ b/yarn.lock
@@ -771,6 +771,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.9.tgz#a07bfa74331471e1dc22a47eb72026843f7b95c8"
   integrity sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA==
 
+"@types/once@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/once/-/once-1.4.0.tgz#7bfe3d99a0951f3141bac2617c9827525788b8f5"
+  integrity sha512-cnEvTAVVRqF6OQg/4SLnbxQ0slZJHqZQDve5BzGhcIQtuMpPv8T5QNS2cBPa/W0jTxciqwn7bmJAIGe/bOJ5Kw==
+
 "@types/prop-types@*", "@types/prop-types@^15.5.6":
   version "15.5.6"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"


### PR DESCRIPTION
One of my least-favorite parts of `enzyme-context` has been the fact that it returns an object with a `component` property (and properties for each plugin.) This API is bad for a number of reasons:

* It makes it more tedious to convert existing tests to use enzyme-context
* It introduces friction to adopting the library because of the divergence with Enzyme's API
* You have to do a funky parens-wrapped destructure (`({ component }) = mount());`)
* It is opinionated about naming Enzyme wrappers `component` (which is my personal preference, even though enzyme itself uses `wrapper`)

I've decided there's no reason this library can't just attach plugins directly to an Enzyme wrapper and just return that directly instead.

So, before:
```jsx
let component;
let store;
({ component, store } = mount(<MyComponent />));
store.dispatch({});
```

After:
```jsx
const wrapper = mount(<MyComponent />);
wrapper.store.dispatch({});
```

However, **this is not a breaking change** because a `component` attribute will also be added to the returned Enzyme wrapper. Enzyme-Context will also log a deprecation warning when that attribute is accessed.