### PR TITLE
Allow to pass config with history

### DIFF
--- a/packages/enzyme-context-react-router-3/src/enzyme-context-react-router-3.spec.tsx
+++ b/packages/enzyme-context-react-router-3/src/enzyme-context-react-router-3.spec.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { createMount, GetContextWrapper } from 'enzyme-context';
 import { ReactWrapper, MountRendererProps } from 'enzyme';
-import { withRouter, WithRouterProps, Route } from 'react-router';
+import { withRouter, WithRouterProps, Route, hashHistory } from 'react-router';
 import { routerContext } from '.';
 import { GetOptions } from 'enzyme-context/src';
 
@@ -76,5 +76,24 @@ describe('enzyme-context-react-router-3', () => {
       },
     );
     expect(component.text()).toBe('1');
+  });
+
+  it('allows to use history from config', () => {
+    const hashHistoryMount = createMount({
+      history: routerContext({
+        history: hashHistory,
+      }),
+    });
+
+    const hashHistoryComponent = hashHistoryMount(<ComponentWithRouter />);
+
+    expect(hashHistoryComponent.exists()).toBe(true);
+    expect(hashHistoryComponent.text()).toBe('Path is: /');
+
+    hashHistory.push('/foo/bar');
+
+    expect(hashHistoryComponent.text()).toBe('Path is: /foo/bar');
+
+    hashHistoryComponent.unmount();
   });
 });

--- a/packages/enzyme-context-react-router-3/src/index.tsx
+++ b/packages/enzyme-context-react-router-3/src/index.tsx
@@ -8,11 +8,17 @@ export interface RouterPluginMountOptions {
   routerConfig?: HistoryOptions & MemoryHistoryOptions;
 }
 
-export const routerContext: () => EnzymePlugin<RouterPluginMountOptions, History> = () => (
+export type RouterPluginConfig = {
+  history?: History;
+};
+
+export const routerContext: (
+  config?: RouterPluginConfig,
+) => EnzymePlugin<RouterPluginMountOptions, History> = (config: RouterPluginConfig = {}) => (
   node,
   options,
 ) => {
-  const history = createMemoryHistory(options.routerConfig);
+  const history = config.history || createMemoryHistory(options.routerConfig);
   const context = new ContextWatcher(
     Watcher => (
       <Router history={history}>


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

This introduces config to react3 router, so tests now can be run using any external history.