### PR TITLE
Add enzyme-context-react-router-6 plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,10 @@ typings/
 
 # Build
 packages/*/dist/
+
+# tsbuildinfo
+**/tsconfig.tsbuildinfo
+**/tsconfig.test.tsbuildinfo
+
+# DS_Store
+**/.DS_Store

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.11.1",
     "tslint-config-prettier": "^1.16.0",
-    "typescript": "^3.1.6"
+    "typescript": "^4.7.2"
   },
   "resolutions": {
     "babel-plugin-istanbul": "file:./babel-plugin-istanbul.tgz"

--- a/packages/enzyme-context-apollo-3/src/enzyme-context-apollo.spec.tsx
+++ b/packages/enzyme-context-apollo-3/src/enzyme-context-apollo.spec.tsx
@@ -42,7 +42,7 @@ const TestQuery = gql`
 const MyComponent: React.SFC = () => {
   return (
     <Query query={TestQuery}>
-      {({ data }) => (
+      {({ data }: any) => (
         <div>
           Street: {data && data.address && data.address.street}
           <br />

--- a/packages/enzyme-context-apollo/src/enzyme-context-apollo.spec.tsx
+++ b/packages/enzyme-context-apollo/src/enzyme-context-apollo.spec.tsx
@@ -46,7 +46,7 @@ const TestQuery = gql`
 const MyComponent: React.SFC = () => {
   return (
     <Query query={TestQuery}>
-      {({ data }) => (
+      {({ data }: any) => (
         <div>
           Street: {data && data.address && data.address.street}
           <br />

--- a/packages/enzyme-context-react-router-6/README.md
+++ b/packages/enzyme-context-react-router-6/README.md
@@ -1,0 +1,95 @@
+# enzyme-context-react-router-4
+
+## Introduction
+
+This plugin sets up the context required for `react-router` (v6) and exposes a `history` instance so that tests can manipulate the URL. With this plugin enabled, it is possible to mount all `react-router` components in your test, including `<Link />`, `<Route />`, etc.
+
+## Installation
+
+1. Setup required peer dependencies: [enzyme](https://airbnb.io/enzyme/docs/installation/), [react](https://reactjs.org/docs/getting-started.html), [react-router v6](https://reactrouter.com/docs/en/v6/getting-started/overview), and [react-test-renderer](https://reactjs.org/docs/test-renderer.html).
+
+2. Install via yarn or npm
+
+   ```bash
+   $> yarn add -D enzyme-context enzyme-context-react-router-6
+   ```
+
+3. Add to plugins:
+
+   ```javascript
+   import { createMount, createShallow } from 'enzyme-context';
+   import { routerContext } from 'enzyme-context-react-router-4';
+
+   const plugins = {
+     history: routerContext(),
+   };
+
+   export const mount = createMount(plugins);
+   export const shallow = createShallow(plugins);
+   ```
+
+## Usage
+
+After adding the plugin to your `mount`/`shallow`, it can be used in your tests like so:
+
+```javascript
+import { mount } from './test-utils/enzyme'; // import the mount created with enzyme-context
+import { Route } from 'react-router-dom';
+import MyComponent from './MyComponent';
+
+describe('<MyComponent />', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<Route path="/my/path" component={MyComponent} />);
+  });
+
+  it('renders when active', () => {
+    expect(wrapper.find(MyComponent).exists()).toBe(false);
+    wrapper.history.push('/my/path');
+    wrapper.update();
+    expect(wrapper.find(MyComponent).exists()).toBe(true);
+  });
+});
+```
+
+## Configuration API
+
+### `routerContext() => EnzymePlugin`
+
+#### Returns
+
+`EnzymePlugin`: The plugin which can be passed to `createMount`/`createShallow`.
+
+#### Example:
+
+```javascript
+import { createMount, createShallow } from 'enzyme-context';
+import { routerContext } from 'enzyme-context-react-router-6';
+
+const plugins = {
+  history: routerContext(),
+};
+
+export const mount = createMount(plugins);
+export const shallow = createShallow(plugins);
+```
+
+## Mount/Shallow API
+
+This plugin also allows some configuration to be passed at mount-time:
+
+1. `routerConfig` (`Object` [optional]): any of the configuration [options of `history`'s `createMemoryHistory()`](https://github.com/ReactTraining/history#usage). For example, we can set the URL _before_ our component mounts like so:
+   ```javascript
+   const wrapper = mount(<MyComponent />, {
+     routerConfig: {
+       initialEntries: ['/my/url'],
+     },
+   });
+   ```
+2. `location` (`Partial<Location> | string` [optional]). Additionally, we can set the location before mount:
+   ```javascript
+   const wrapper = mount(<MyComponent />, {
+     location: '/my/url',
+   });
+   ```

--- a/packages/enzyme-context-react-router-6/jest.config.js
+++ b/packages/enzyme-context-react-router-6/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest.config.base');
+
+module.exports = {
+  ...base,
+};

--- a/packages/enzyme-context-react-router-6/package.json
+++ b/packages/enzyme-context-react-router-6/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "enzyme-context-react-router-6",
+  "version": "1.0.0",
+  "keywords": [
+    "enzyme",
+    "react",
+    "context",
+    "plugins",
+    "react-router",
+    "testing",
+    "javascript",
+    "typescript"
+  ],
+  "scripts": {
+    "test": "jest",
+    "build": "tsc -b .",
+    "check-types": "tsc -p ./tsconfig.json --noEmit --pretty && tsc -p ./tsconfig.test.json --noEmit --pretty",
+    "lint": "tslint -p ./tsconfig.json && tslint -p ./tsconfig.test.json",
+    "prepublish": "yarn build && yarn check-types && yarn lint && yarn test"
+  },
+  "dependencies": {
+    "enzyme-context-utils": "^1.1.0",
+    "history": "^5.3.0"
+  },
+  "description": "Initialize react-router v4 context with enzyme-context",
+  "main": "dist/index.js",
+  "files": [
+    "dist/**"
+  ],
+  "repository": "https://github.com/trialspark/enzyme-context",
+  "author": "TrialSpark, Inc.",
+  "license": "MIT",
+  "peerDependencies": {
+    "enzyme": ">=3.10",
+    "react": ">=15",
+    "react-router": "6.x"
+  },
+  "devDependencies": {
+    "react-router": "^6.3.0",
+    "react-router-dom": "^6.3.0"
+  }
+}

--- a/packages/enzyme-context-react-router-6/src/enzyme-context-react-router-6.spec.tsx
+++ b/packages/enzyme-context-react-router-6/src/enzyme-context-react-router-6.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { createMount, GetContextWrapper } from 'enzyme-context';
+import { ReactWrapper } from 'enzyme';
+import { Route, Routes, useParams } from 'react-router-dom';
+import { routerContext } from '.';
+import { act } from 'react-dom/test-utils';
+
+const MyComponent: React.FC = () => {
+  const { id } = useParams();
+  return <div>id is: {id}</div>;
+};
+
+describe('enzyme-context-react-router-6', () => {
+  let wrapper: GetContextWrapper<ReactWrapper, Plugins>;
+
+  type Plugins = {
+    history: ReturnType<typeof routerContext>;
+  };
+
+  const page = () => wrapper.find(MyComponent);
+
+  beforeEach(() => {
+    const mount = createMount({
+      history: routerContext(),
+    });
+    wrapper = mount(
+      <Routes>
+        <Route path="/my/url/:id" element={<MyComponent />} />
+      </Routes>,
+    );
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('exists', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('returns history as a controller', () => {
+    expect(page().exists()).toBe(false);
+
+    act(() => {
+      wrapper.history.push('/my/url/1612');
+    });
+    wrapper.update();
+    expect(page().text()).toBe('id is: 1612');
+  });
+
+  it('responds to history after the component is remounted', () => {
+    wrapper.unmount();
+    wrapper.mount();
+    expect(page().exists()).toBe(false);
+
+    act(() => {
+      wrapper.history.push('/my/url/1612');
+    });
+    wrapper.update();
+    expect(page().exists()).toBe(true);
+  });
+
+  it('allows configuration to be passed', () => {
+    const mount = createMount({
+      history: routerContext(),
+    });
+    wrapper = mount(
+      <Routes>
+        <Route path="/my/url/:id" element={<MyComponent />} />
+      </Routes>,
+      {
+        routerConfig: {
+          initialEntries: ['/my/url/44'],
+        },
+      },
+    );
+    expect(page().text()).toBe('id is: 44');
+  });
+});

--- a/packages/enzyme-context-react-router-6/src/index.tsx
+++ b/packages/enzyme-context-react-router-6/src/index.tsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import { EnzymePlugin, composeWrappingComponents } from 'enzyme-context-utils';
+import { Router } from 'react-router';
+import { createMemoryHistory, Location, MemoryHistory, MemoryHistoryOptions } from 'history';
+
+export type RouterPluginMountOptions = {
+  routerConfig?: MemoryHistoryOptions;
+  location?: Location | string;
+};
+
+export const routerContext: () => EnzymePlugin<RouterPluginMountOptions, MemoryHistory> = () => (
+  node,
+  options,
+) => {
+  const history = createMemoryHistory(options.routerConfig);
+  const RouterContextProvider: React.FC = ({ children }) => {
+    const [currentLocation, setCurrentLocation] = useState(options.location || history.location);
+
+    useEffect(() => {
+      const unlisten = history.listen(({ location }) => {
+        setCurrentLocation(location);
+      });
+      return () => unlisten();
+    }, []);
+
+    return (
+      <Router location={currentLocation} navigator={history}>
+        {children}
+      </Router>
+    );
+  };
+
+  return {
+    node,
+    controller: history,
+    options: {
+      wrappingComponent: composeWrappingComponents(
+        options.wrappingComponent,
+        RouterContextProvider,
+      ),
+    },
+  };
+};

--- a/packages/enzyme-context-react-router-6/tsconfig.json
+++ b/packages/enzyme-context-react-router-6/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*.ts", "./src/**/*.tsx"],
+  "exclude": ["./src/**/*.spec.*"],
+  "references": [{ "path": "../enzyme-context-utils" }]
+}

--- a/packages/enzyme-context-react-router-6/tsconfig.test.json
+++ b/packages/enzyme-context-react-router-6/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig-base.test.json",
+  "include": ["./src/**/*.spec.*"],
+  "references": [
+    { "path": "./tsconfig.json" },
+    { "path": "../enzyme-context" },
+    { "path": "../enzyme-context-utils" }
+  ]
+}

--- a/packages/enzyme-context/src/Utils.ts
+++ b/packages/enzyme-context/src/Utils.ts
@@ -81,7 +81,7 @@ export function hookIntoLifecycle<
   PR extends PluginReturns<any, any>,
   W extends ReactWrapper | ShallowWrapper
 >(pluginResults: PR, wrapper: W): void {
-  const unmount = wrapper.unmount;
+  const unmount = wrapper.unmount as () => W;
   const mount = wrapper instanceof ReactWrapper ? wrapper.mount : null;
   const lifecycle = new LifecycleTracker(wrapper, pluginResults.updaters);
 
@@ -118,7 +118,7 @@ export function hookIntoLifecycle<
     return result;
   }
 
-  wrapper.unmount = patchedUnmount;
+  (wrapper.unmount as () => W) = patchedUnmount;
 
   if (wrapper instanceof ReactWrapper) {
     wrapper.mount = patchedMount;
@@ -164,5 +164,5 @@ export function decorateEnzymeWrapper<
         return wrapper;
       },
     },
-  });
+  }) as GetContextWrapper<EW, P>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,6 +174,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.7.6":
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
+  integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -3850,6 +3857,13 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^0.4.0"
 
+history@^5.2.0, history@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hoist-non-react-statics@^2.3.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
@@ -6791,6 +6805,14 @@ react-router-dom@^5.0.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
 react-router@5.0.1, react-router@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.1.tgz#04ee77df1d1ab6cb8939f9f01ad5702dbadb8b0f"
@@ -6806,6 +6828,13 @@ react-router@5.0.1, react-router@^5.0.1:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-router@6.3.0, react-router@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-router@^3.2.1:
   version "3.2.4"
@@ -7005,6 +7034,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regex-cache@^0.4.2:
   version "0.4.4"
@@ -8049,10 +8083,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+typescript@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
+  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
Add plugin to support react-router v6: enzyme-context-react-router-6 plugin. This required bumping typescript as the v6 types use newer syntax.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
